### PR TITLE
Use maxRecordCount as idsplits

### DIFF
--- a/R/retrieve_layers.R
+++ b/R/retrieve_layers.R
@@ -72,9 +72,10 @@ get_spatial_layer <- function(url,
     sf_type <- layer_info$geometryType
   }
   query_url <- paste(url, "query", sep="/")
-  esri_features <- get_esri_features(
-    query_url, out_fields, where, token, head, ...
-  )
+  args <- list(query_url, out_fields, where, token, head, ...)
+  if(!"idsplits" %in% names(args))
+    args <- c(args, list(idsplits = layer_info$maxRecordCount))
+  esri_features <- do.call(get_esri_features, args)
   simple_features <- esri2sfGeom(esri_features, sf_type)
   return(simple_features)
 }


### PR DESCRIPTION
So that the user does not need to figure out the right value for idsplits themselves, just use `layer_info$maxRecordCount` as the idsplits value.

Basically I ran into the same issue as #4 and found that queries return the expected results by calling `get_spatial_layer(..., idsplits = maxRecordCount)`.

For example, arcpullr currently returns 150 records for this query, while the code on my branch returns all 166:
```
get_spatial_layer(
  "https://www.portlandmaps.com/arcgis/rest/services/Public/COP_OpenData_PlanningDevelopment/MapServer/207"
)
```

If you visit that layer URL, you'll see there "MaxRecordCount: 150".

I've written the code so that users can still pass `idsplits` themselves. It will only be set to `layer_info$maxRecordCount` if idsplits is missing from the dots (...). This should preserve backward compatibility for anyone who currently passes idsplits to `get_spatial_layer()`.