### PR TITLE
remove rgdal

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,8 +33,7 @@ Imports:
     raster (>= 3.4.5),
     methods,
     bslib,
-    DT,
-    rgdal
+    DT
 RoxygenNote: 7.2.1
 Suggests: 
   testthat (>= 3.0.1),


### PR DESCRIPTION
I did a search for any functions used from rgdal and can't find any. I think you can just drop the import. 

to check this I did

```R
xseek <- lsf.str("package:rgdal")

allcode <- unlist(lapply(fs::dir_ls("R", regexp = "\\.R$"), readLines))
for (i in seq_along(xseek)) {
  if (any(grepl(xseek[i], allcode))) {
    print(xseek[i])
  }
  
}

```

the only thing printed out is "project", but that's just in the code not using the rgdal package 